### PR TITLE
updated readme docs for terabox-node.

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,4 +1,9 @@
 ## Configuration
+Goto repository folder and install all needed dependencies, because nothing is compiled and no executable.
+```bash
+cd terabox-node
+npm install
+```
 
 1. Open your Terabox cloud.
 2. Open the browser's developer tools (F12).
@@ -6,8 +11,11 @@
 4. Select the "Cookies" item in the left panel.
 5. Look for the "ndus" cookie value and copy it to ".config.yaml".
 
+You can add multiple accounts and access their files and folders.
+
+In config.yaml
 ```yaml
 accounts:
-  MyMainAcc: Y-DSDSD...
-  MySecondAcc: YDvrwD...
+  MainAcc: Y-DSDSD...
+  SecondAcc: YDvrwD...
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,56 @@
-# TeraBox App CLI (NodeJS)
 
-NodeJS CLI tool for downloading/uploading files from/to your TeraBox cloud account without having to use the website or app.
+# TeraBox Node
+A nodejs tool to interact with terabox cloud account ☁
 
-- [Configuration](CONFIGURATION.md)
-- [Usage](USAGE.md)
+## Features
+- TeraBox Files Downloading
+- TeraBox Files Uploading
+- 100% Built on Javascript
+- Rapid Upload Support 
+    - (files can be uploaded instantly without waiting if file was uploaded before to terabox)
+## Acknowledgements
+You need to know atleast basics about these things.
+ - [NodeJS](https://nodejs.org/docs/latest/api/)
+- Debian, Ubuntu or Fedora
+- You should have [NodeJS](https://nodejs.org/en) installed on your device including package managers.
+
+## Installation
+Clone this repository to your local machine via this command:
+
+```bash
+git clone https://github.com/OurCodeBase/terabox-node
+```
+## Documentation
+- [Configurations](CONFIGURATION.md) - You have to configure this app before use.
+- [Usage](USAGE.md) - After you've configured the tool then you're good to go with usage commands.
+
+## Roadmap
+This tool is in it's initial phase and not much stable, some of the features are not available for now. We are working daily to provide a better tool.
+
+You can check the below table to find out features.
+
+| **Features** | **Active** |                           **Notes**                           |
+|:------------:|:----------:|:-------------------------------------------------------------:|
+|   Download   |     No     | Use [alist](https://github.com/alist-org/alist) tool for now. |
+|    Upload    |     Yes    |            Currently working excluding a good cli.            |
+| Rapid Upload |     Yes    |                 Working but unstable for now.                 |
+
+
+## Milestone
+We are working to improve some features of this tool.
+
+|        **Features**        | **Workon** |                          **State**                         |
+|:--------------------------:|:----------:|:----------------------------------------------------------:|
+| Package Manager Compatible |    Soon    |                  Will work on future soon                  |
+|       User Interface       |     On     | - improving user interface using chalk and other packages. |
+|   Stable Download Feature  |    Soon    |                  Will work on future soon                  |
+|      Folder Structure      |    Soon    |                  Will work on future soon                  |
+|          Stablity          |    Soon    |                  Will work on future soon                  |
+
+## Authors
+- [@seiya-dev](https://github.com/seiya-dev/terabox-app-js) as Creator
+- [@OurCodeBase](https://github.com/OurCodeBase/terabox-node) as Contributor
+
+## Contributing
+Contributions are always welcome!
+- [@OurCodeBase](https://github.com/OurCodeBase/terabox-node)

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,11 +41,11 @@ We are working to improve some features of this tool.
 
 |        **Features**        | **Workon** |                          **State**                         |
 |:--------------------------:|:----------:|:----------------------------------------------------------:|
-| Package Manager Compatible |    Soon    |                  Will work on future soon                  |
+| Package Manager Compatible |    Soon    |                  Will work in future soon                  |
 |       User Interface       |     On     | - improving user interface using chalk and other packages. |
-|   Stable Download Feature  |    Soon    |                  Will work on future soon                  |
-|      Folder Structure      |    Soon    |                  Will work on future soon                  |
-|          Stablity          |    Soon    |                  Will work on future soon                  |
+|   Stable Download Feature  |    Soon    |                  Will work in future soon                  |
+|      Folder Structure      |    Soon    |                  Will work in future soon                  |
+|          Stablity          |    Soon    |                  Will work in future soon                  |
 
 ## Authors
 - [@seiya-dev](https://github.com/seiya-dev/terabox-app-js) as Creator

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,34 +1,34 @@
-# Usage
-Install NodeJS version 20 or higher. Then install required modules with npm (or other preferred package manager).
 
-## Scripts
+## Usage
+These  are some files for now to use `terabox-node`.
 
-### Check Accounts:
-**node "app-check.js"**
+### Check Accounts
+This command checks that your accounts are finely working or not.
+```bash
+node app-check.js
 ```
-no options for this script
+
+### Upload Folders/Files
+To upload files or folders to terabox use this command.
+```bash
+node app-uploader.js <options> <values>
 ```
-### Upload Folders/Files:
-**node "app-uploader.js"**
+```bash
+<options>
+    -a "acc"           select account (by name from ".config.yaml")
+    -l "/"             select local directory
+    -r "/"             select remote directory
+    --no-rapidupload   don't use rapidupload function
 ```
--a "acc"           select account (by name from ".config.yaml")
--l "/"             select local directory
--r "/"             select remote directory
---no-rapidupload   don't use rapidupload function
+
+### Download Folders/Files
+We are working on downloading files from terabox.
+```bash
+NOT AVAILABLE FOR NOW
 ```
-### Create TBHash for RapidUpload:
-**node "app-mktbhash.js"**
-```
--l "/"             select local directory
---skip-chunks      don't create chunck hashes
-```
-### Download Files from Remote:
-**node "app-getdl.js"**
-```
-IN DEVELOPMENT, use alist for now
-```
-### Fetch File Meta Information from Remote:
-**node "app-filemeta.js"**
-```
-IN DEVELOPMENT
+
+### Metadata Files
+We are constantly working on providing you metadata of files from terabox.
+```bash
+NOT AVAILABLE FOR NOW
 ```

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "terabox-app-js",
-    "name_ext": "Terabox App",
+    "name": "terabox-node",
+    "name_ext": "TeraBox Node",
     "version": "2.0.0",
     "main": "app.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
     "keywords": [
-        "terabox"
+        "terabox",
+        "crawler",
+        "api",
+        "node"
     ],
     "author": "Seiya Dev.",
     "license": "MIT",
-    "description": "",
+    "description": "A nodejs tool to interact with terabox cloud account ☁️",
     "type": "module",
     "dependencies": {
         "@inquirer/input": "^2.3.0",


### PR DESCRIPTION
- milestone and roadmap headers are added.
- more important points has been explained.

If you don't want `terabox-node` as your repo name you can modify your readme.